### PR TITLE
Fixing rules for terminals involving < and >

### DIFF
--- a/parser.nex
+++ b/parser.nex
@@ -14,9 +14,9 @@
 /\=/        { return '=' }
 /\</        { return '<' }
 /\>/        { return '>' }
-/>=/        { return TK_GTE }
-/<=/        { return TK_LTE }
-/<>/        { return TK_NE }
+/\>=/        { return TK_GTE }
+/\<=/        { return TK_LTE }
+/\<\>/        { return TK_NE }
 
 /[lL][iI][kK][eE]/ { return KW_LIKE }
 /[bB][eE][tT][wW][eE][eE][nN]/ { return KW_BETWEEN }


### PR DESCRIPTION
Turns out these characters have a special meaning for Nex and were causing hard-to-track issues in the parser