### PR TITLE
Correcting quotes and unnecessary escapes

### DIFF
--- a/parser.nex
+++ b/parser.nex
@@ -9,9 +9,9 @@
 /\)/        { return ')' }
 /\"/        { return TK_QUOTES }
 /\./        { return '.' }
-/\;/        { return ';' }
-/\,/        { return ',' }
-/\=/        { return '=' }
+/;/        { return ';' }
+/,/        { return ',' }
+/=/        { return '=' }
 /\</        { return '<' }
 /\>/        { return '>' }
 /\>=/        { return TK_GTE }
@@ -51,7 +51,7 @@
 /[iI][sS]/ { return KW_IS }
 /[aA][uU][tT][oO]_[iI][nN][cC][rR][eE][mM][eE][nN][tT]/{ return KW_AUTO_INCREMENT}
 /[a-zA-Z][a-zA-Z0-9_]*/ { return TK_ID }
-/[^"]*/ { lval.string_t = yylex.Text();  return TK_WORD }
+/'[^']*'/ { lval.string_t = yylex.Text();  return TK_WORD }
 /./         {
                 fmt.Printf(yylex.Text())
                 //panic(fmt.Sprintf("There's an unexpected token '%s' here", yylex.Text()))


### PR DESCRIPTION
* Unescaped comma, semicolon and equals since they're not regex symbols (as far as I know)
* Corrected the lexer rule to match string literals to capture everything inside two single quotes instead of everything that wasn't double quotes