### PR TITLE
AST Conversion to common structs and type cohersion

### DIFF
--- a/expressions.go
+++ b/expressions.go
@@ -9,7 +9,7 @@ type idExpression struct {
 }
 
 type intExpression struct {
-	value int
+	value int32
 }
 
 type boolExpression struct {
@@ -17,7 +17,7 @@ type boolExpression struct {
 }
 
 type floatExpression struct {
-	value float64
+	value float32
 }
 
 type stringExpression struct {
@@ -82,7 +82,7 @@ type likeExpression struct {
 	leftValue  expression
 }
 
-	type notExpression struct {
+type notExpression struct {
 	not expression
 }
 type andExpression struct {

--- a/expressions.go
+++ b/expressions.go
@@ -9,7 +9,7 @@ type idExpression struct {
 }
 
 type intExpression struct {
-	value int32
+	value int64
 }
 
 type boolExpression struct {
@@ -17,7 +17,7 @@ type boolExpression struct {
 }
 
 type floatExpression struct {
-	value float32
+	value float64
 }
 
 type stringExpression struct {

--- a/helpers.go
+++ b/helpers.go
@@ -48,7 +48,7 @@ func (c *columnDefinition) convert() common.TableColumnDefiner {
 	case *floatType:
 		return common.NewFloatTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
 	case *charType:
-		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), v.length)
+		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), uint32(v.length))
 	}
 
 	return nil

--- a/helpers.go
+++ b/helpers.go
@@ -49,7 +49,7 @@ func (c *columnDefinition) convert() common.TableColumnDefiner {
 	case *datetimeType:
 		return common.NewDatetimeTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
 	case *charType:
-		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), uint32(v.length))
+		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), uint16(v.length))
 	}
 
 	return nil

--- a/helpers.go
+++ b/helpers.go
@@ -39,7 +39,6 @@ type columnDefinition struct {
 }
 
 func (c *columnDefinition) convert() common.TableColumnDefiner {
-
 	switch v := c.dataType.(type) {
 	case *booleanType:
 		return common.NewBooleanTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
@@ -47,6 +46,8 @@ func (c *columnDefinition) convert() common.TableColumnDefiner {
 		return common.NewIntegerTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
 	case *floatType:
 		return common.NewFloatTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
+	case *datetimeType:
+		return common.NewDatetimeTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
 	case *charType:
 		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), uint32(v.length))
 	}

--- a/helpers.go
+++ b/helpers.go
@@ -41,6 +41,12 @@ type columnDefinition struct {
 func (c *columnDefinition) convert() common.TableColumnDefiner {
 
 	switch v := c.dataType.(type) {
+	case *booleanType:
+		return common.NewBooleanTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
+	case *integerType:
+		return common.NewIntegerTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
+	case *floatType:
+		return common.NewFloatTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable())
 	case *charType:
 		return common.NewCharTableColumn(c.identifier, c.defaultValue(), c.nullable(), c.autoincrementable(), v.length)
 	}

--- a/lexer.go
+++ b/lexer.go
@@ -7628,12 +7628,12 @@ OUTER0:
 			}
 		case 3:
 			{
-				lval.int_t, _ = strconv.Atoi(yylex.Text())
+				lval.int32_t, _ = strconv.ParseInt(yylex.Text(), 10, 32).(int32)
 				return INT_LIT
 			}
 		case 4:
 			{
-				lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 64)
+				lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 32).(float32)
 				return FLOAT_LIT
 			}
 		case 5:

--- a/lexer.go
+++ b/lexer.go
@@ -7628,20 +7628,20 @@ OUTER0:
 			}
 		case 3:
 			{
-				n, err := strconv.ParseInt(yylex.Text(), 10, 32)
+				n, err := strconv.ParseInt(yylex.Text(), 10, 64)
 				if err != nil {
 					yylex.Error(err.Error())
 				}
-				lval.int32_t = int32(n)
+				lval.int64_t = n
 				return INT_LIT
 			}
 		case 4:
 			{
-				n, err := strconv.ParseFloat(yylex.Text(), 32)
+				n, err := strconv.ParseFloat(yylex.Text(), 64)
 				if err != nil {
 					yylex.Error(err.Error())
 				}
-				lval.float32_t = float32(n)
+				lval.float64_t = n
 				return FLOAT_LIT
 			}
 		case 5:

--- a/lexer.go
+++ b/lexer.go
@@ -7892,7 +7892,7 @@ OUTER0:
 			}
 		case 66:
 			{
-				lval.string_t = strings.ToLower(yylex.Text())
+				lval.string_t = strings.ToUpper(yylex.Text())
 				return TK_ID
 			}
 		case 67:

--- a/lexer.go
+++ b/lexer.go
@@ -7628,12 +7628,20 @@ OUTER0:
 			}
 		case 3:
 			{
-				lval.int32_t, _ = strconv.ParseInt(yylex.Text(), 10, 32).(int32)
+				n, err := strconv.ParseInt(yylex.Text(), 10, 32)
+				if err != nil {
+					yylex.Error(err.Error())
+				}
+				lval.int32_t = int32(n)
 				return INT_LIT
 			}
 		case 4:
 			{
-				lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 32).(float32)
+				n, err := strconv.ParseFloat(yylex.Text(), 32)
+				if err != nil {
+					yylex.Error(err.Error())
+				}
+				lval.float32_t = float32(n)
 				return FLOAT_LIT
 			}
 		case 5:
@@ -7889,27 +7897,15 @@ OUTER0:
 			}
 		case 67:
 			{
-				panic(Error{
-					line:    yylex.Line() + 1,
-					column:  yylex.Column() + 1,
-					message: fmt.Sprintf("syntax error: unterminated string literal"),
-				})
+				yylex.Error(fmt.Sprintf("syntax error: unterminated string literal"))
 			}
 		case 68:
 			{
-				panic(Error{
-					line:    yylex.Line() + 1,
-					column:  yylex.Column() + 1,
-					message: fmt.Sprintf("syntax error: unterminated string literal"),
-				})
+				yylex.Error(fmt.Sprintf("syntax error: unterminated string literal"))
 			}
 		case 69:
 			{
-				panic(Error{
-					line:    yylex.Line() + 1,
-					column:  yylex.Column() + 1,
-					message: fmt.Sprintf("syntax error: unexpected token '%s'", yylex.Text()),
-				})
+				yylex.Error(fmt.Sprintf("syntax error: unexpected token '%s'", yylex.Text()))
 			}
 		default:
 			break OUTER0

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -89,8 +89,8 @@ func TestLexer(t *testing.T) {
 	tokenCount := 0
 	expectedTokenCount := 65
 
-	var integers []int32
-	var floats []float32
+	var integers []int64
+	var floats []float64
 	var strings []string
 	var identifiers []string
 	var keywords []int
@@ -101,9 +101,9 @@ func TestLexer(t *testing.T) {
 		tokenCount++
 
 		if token == INT_LIT {
-			integers = append(integers, lval.int32_t)
+			integers = append(integers, lval.int64_t)
 		} else if token == FLOAT_LIT {
-			floats = append(floats, lval.float32_t)
+			floats = append(floats, lval.float64_t)
 		} else if token == STR_LIT {
 			strings = append(strings, lval.string_t)
 		} else if token == TK_ID {
@@ -124,7 +124,7 @@ func TestLexer(t *testing.T) {
 	}
 
 	t.Run("TestIntegerLiterals", func(t *testing.T) {
-		expectedValue := int32(27819)
+		expectedValue := int64(27819)
 		expectedIntCount := 1
 		intCount := len(integers)
 
@@ -138,7 +138,7 @@ func TestLexer(t *testing.T) {
 	})
 
 	t.Run("TestFloatLiterals", func(t *testing.T) {
-		expectedValue := float32(3.1416)
+		expectedValue := float64(3.1416)
 		expectedFloatCount := 1
 		floatCount := len(floats)
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -170,7 +170,7 @@ func TestLexer(t *testing.T) {
 	})
 
 	t.Run("TestIdentifiers", func(t *testing.T) {
-		expectedIdentifiers := []string{"movies", "movies", "title", "movies2"}
+		expectedIdentifiers := []string{"MOVIES", "MOVIES", "TITLE", "MOVIES2"}
 		expectedIdentifierCount := len(expectedIdentifiers)
 		identifierCount := len(identifiers)
 

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -89,8 +89,8 @@ func TestLexer(t *testing.T) {
 	tokenCount := 0
 	expectedTokenCount := 65
 
-	var integers []int
-	var floats []float64
+	var integers []int32
+	var floats []float32
 	var strings []string
 	var identifiers []string
 	var keywords []int
@@ -101,9 +101,9 @@ func TestLexer(t *testing.T) {
 		tokenCount++
 
 		if token == INT_LIT {
-			integers = append(integers, lval.int_t)
+			integers = append(integers, lval.int32_t)
 		} else if token == FLOAT_LIT {
-			floats = append(floats, lval.float_t)
+			floats = append(floats, lval.float32_t)
 		} else if token == STR_LIT {
 			strings = append(strings, lval.string_t)
 		} else if token == TK_ID {
@@ -124,7 +124,7 @@ func TestLexer(t *testing.T) {
 	}
 
 	t.Run("TestIntegerLiterals", func(t *testing.T) {
-		expectedValue := 27819
+		expectedValue := int32(27819)
 		expectedIntCount := 1
 		intCount := len(integers)
 
@@ -138,7 +138,7 @@ func TestLexer(t *testing.T) {
 	})
 
 	t.Run("TestFloatLiterals", func(t *testing.T) {
-		expectedValue := 3.1416
+		expectedValue := float32(3.1416)
 		expectedFloatCount := 1
 		floatCount := len(floats)
 

--- a/parser.go
+++ b/parser.go
@@ -13,9 +13,9 @@ var statements statementList
 //line parser.y:13
 type yySymType struct {
 	yys       int
-	int32_t   int32
+	int64_t   int64
 	string_t  string
-	float32_t float32
+	float64_t float64
 
 	expr_t expression
 
@@ -809,7 +809,7 @@ yydefault:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		//line parser.y:111
 		{
-			yyVAL.data_t = &charType{yyDollar[3].int32_t}
+			yyVAL.data_t = &charType{yyDollar[3].int64_t}
 		}
 	case 22:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -1012,7 +1012,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		//line parser.y:174
 		{
-			yyVAL.obj_t = yyDollar[1].int32_t
+			yyVAL.obj_t = yyDollar[1].int64_t
 		}
 	case 55:
 		yyDollar = yyS[yypt-4 : yypt+1]
@@ -1181,7 +1181,7 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line parser.y:228
 		{
-			yyVAL.expr_t = &betweenExpression{&intExpression{yyDollar[1].int32_t}, &intExpression{yyDollar[3].int32_t}}
+			yyVAL.expr_t = &betweenExpression{&intExpression{yyDollar[1].int64_t}, &intExpression{yyDollar[3].int64_t}}
 		}
 	case 83:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -1223,7 +1223,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		//line parser.y:241
 		{
-			yyVAL.expr_t = &intExpression{yyDollar[1].int32_t}
+			yyVAL.expr_t = &intExpression{yyDollar[1].int64_t}
 		}
 	case 90:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/parser.go
+++ b/parser.go
@@ -805,7 +805,7 @@ yydefault:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		//line parser.y:111
 		{
-			yyVAL.data_t = &charType{yyDollar[3].int32_t.(int)}
+			yyVAL.data_t = &charType{yyDollar[3].int32_t}
 		}
 	case 22:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/parser.go
+++ b/parser.go
@@ -12,10 +12,10 @@ var statements statementList
 
 //line parser.y:13
 type yySymType struct {
-	yys      int
-	int_t    int
-	string_t string
-	float_t  float64
+	yys       int
+	int32_t   int32
+	string_t  string
+	float32_t float32
 
 	expr_t expression
 
@@ -805,7 +805,7 @@ yydefault:
 		yyDollar = yyS[yypt-4 : yypt+1]
 		//line parser.y:111
 		{
-			yyVAL.data_t = &charType{yyDollar[3].int_t}
+			yyVAL.data_t = &charType{yyDollar[3].int32_t.(int)}
 		}
 	case 22:
 		yyDollar = yyS[yypt-1 : yypt+1]
@@ -990,7 +990,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		//line parser.y:171
 		{
-			yyVAL.obj_t = yyDollar[1].int_t
+			yyVAL.obj_t = yyDollar[1].int32_t
 		}
 	case 52:
 		yyDollar = yyS[yypt-4 : yypt+1]
@@ -1159,7 +1159,7 @@ yydefault:
 		yyDollar = yyS[yypt-3 : yypt+1]
 		//line parser.y:225
 		{
-			yyVAL.expr_t = &betweenExpression{&intExpression{yyDollar[1].int_t}, &intExpression{yyDollar[3].int_t}}
+			yyVAL.expr_t = &betweenExpression{&intExpression{yyDollar[1].int32_t}, &intExpression{yyDollar[3].int32_t}}
 		}
 	case 80:
 		yyDollar = yyS[yypt-3 : yypt+1]
@@ -1201,7 +1201,7 @@ yydefault:
 		yyDollar = yyS[yypt-1 : yypt+1]
 		//line parser.y:238
 		{
-			yyVAL.expr_t = &intExpression{yyDollar[1].int_t}
+			yyVAL.expr_t = &intExpression{yyDollar[1].int32_t}
 		}
 	case 87:
 		yyDollar = yyS[yypt-1 : yypt+1]

--- a/parser.go
+++ b/parser.go
@@ -1,9 +1,9 @@
-//line parser.y:3
+//line parser.y:4
 package parser
 
 import __yyfmt__ "fmt"
 
-//line parser.y:5
+//line parser.y:4
 import "io"
 
 /*import "github.com/modest-sql/common"*/

--- a/parser.nex
+++ b/parser.nex
@@ -2,8 +2,8 @@
 /--[^\n]*/      { /* Single line comment */ }
 /\/\*[^*]*\*\// { /* Multi line comment */ }
 
-/-?[0-9]+/	        { lval.int32_t, _ = strconv.ParseInt(yylex.Text(), 10, 32).(int32); return INT_LIT }
-/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 32).(float32); return FLOAT_LIT }
+/-?[0-9]+/	{ n, err := strconv.ParseInt(yylex.Text(), 10, 32); if err != nil { yylex.Error(err.Error()) }; lval.int32_t = int32(n); return INT_LIT }
+/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { n, err := strconv.ParseFloat(yylex.Text(), 32); if err != nil { yylex.Error(err.Error()) }; lval.float32_t = float32(n); return FLOAT_LIT }
 
 
 /\+/        { return TK_PLUS }
@@ -72,29 +72,11 @@
 
 /[a-zA-Z][a-zA-Z0-9_]*/         { lval.string_t = strings.ToLower(yylex.Text()); return TK_ID }
 
-/'(\\.|[^'])*$/	                { 
-                                    panic(Error{
-                                            line: yylex.Line() + 1,
-                                            column: yylex.Column() + 1,
-                                            message: fmt.Sprintf("syntax error: unterminated string literal"),
-                                        })
-                                }
+/'(\\.|[^'])*$/	                { yylex.Error(fmt.Sprintf("syntax error: unterminated string literal")) }
 
-/\"(\\.|[^"])*$/                { 
-                                    panic(Error{
-                                            line: yylex.Line() + 1,
-                                            column: yylex.Column() + 1,
-                                            message: fmt.Sprintf("syntax error: unterminated string literal"),
-                                        })
-                                }
+/\"(\\.|[^"])*$/                { yylex.Error(fmt.Sprintf("syntax error: unterminated string literal")) }
 
-/./                             { 
-                                    panic(Error{
-                                            line: yylex.Line() + 1,
-                                            column: yylex.Column() + 1,
-                                            message: fmt.Sprintf("syntax error: unexpected token '%s'", yylex.Text()),
-                                        })
-                                }
+/./                             { yylex.Error(fmt.Sprintf("syntax error: unexpected token '%s'", yylex.Text())) }
 //
 
 package parser

--- a/parser.nex
+++ b/parser.nex
@@ -2,8 +2,8 @@
 /--[^\n]*/      { /* Single line comment */ }
 /\/\*[^*]*\*\// { /* Multi line comment */ }
 
-/-?[0-9]+/	{ n, err := strconv.ParseInt(yylex.Text(), 10, 32); if err != nil { yylex.Error(err.Error()) }; lval.int32_t = int32(n); return INT_LIT }
-/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { n, err := strconv.ParseFloat(yylex.Text(), 32); if err != nil { yylex.Error(err.Error()) }; lval.float32_t = float32(n); return FLOAT_LIT }
+/-?[0-9]+/	{ n, err := strconv.ParseInt(yylex.Text(), 10, 64); if err != nil { yylex.Error(err.Error()) }; lval.int64_t = n; return INT_LIT }
+/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { n, err := strconv.ParseFloat(yylex.Text(), 64); if err != nil { yylex.Error(err.Error()) }; lval.float64_t = n; return FLOAT_LIT }
 
 
 /\+/        { return TK_PLUS }

--- a/parser.nex
+++ b/parser.nex
@@ -2,8 +2,8 @@
 /--[^\n]*/      { /* Single line comment */ }
 /\/\*[^*]*\*\// { /* Multi line comment */ }
 
-/-?[0-9]+/	        { lval.int_t, _ = strconv.Atoi(yylex.Text()); return INT_LIT }
-/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 64); return FLOAT_LIT }
+/-?[0-9]+/	        { lval.int32_t, _ = strconv.ParseInt(yylex.Text(), 10, 32).(int32); return INT_LIT }
+/-?[0-9]+\.[0-9]*|-?\.[0-9]+|-?[0-9]+[Ee][-+]?[0-9]+|-?[0-9]+\.[0-9]*[Ee][-+]?[0-9]+|-?\.[0-9]*[Ee][-+]?[0-9]+/ { lval.float_t, _ = strconv.ParseFloat(yylex.Text(), 32).(float32); return FLOAT_LIT }
 
 
 /\+/        { return TK_PLUS }

--- a/parser.nex
+++ b/parser.nex
@@ -70,7 +70,7 @@
 /'[^']*'/                       { lval.string_t = strings.Replace(yylex.Text(), "'", "", -1);  return STR_LIT }
 /"[^"]*"/                       { lval.string_t = strings.Replace(yylex.Text(), "\"", "", -1);  return STR_LIT }
 
-/[a-zA-Z][a-zA-Z0-9_]*/         { lval.string_t = strings.ToLower(yylex.Text()); return TK_ID }
+/[a-zA-Z][a-zA-Z0-9_]*/         { lval.string_t = strings.ToUpper(yylex.Text()); return TK_ID }
 
 /'(\\.|[^'])*$/	                { yylex.Error(fmt.Sprintf("syntax error: unterminated string literal")) }
 

--- a/parser.y
+++ b/parser.y
@@ -43,7 +43,7 @@ var statements statementList
 %token KW_TRUE KW_FALSE KW_AS KW_ADD KW_COLUMN
 
 %token<int64_t> INT_LIT
-%token<float32_t> FLOAT_LIT
+%token<float64_t> FLOAT_LIT
 %token<string_t> TK_ID STR_LIT
 %type<string_t> multipart_id_suffix alias_spec
 

--- a/parser.y
+++ b/parser.y
@@ -11,9 +11,9 @@ var statements statementList
 %}
 
 %union {
-    int_t int
+    int32_t int32
     string_t string
-    float_t float64
+    float32_t float32
 
     expr_t expression
 
@@ -42,8 +42,8 @@ var statements statementList
 %token KW_NULL KW_IN KW_IS KW_AUTO_INCREMENT KW_JOIN KW_ON KW_GROUP KW_BY KW_DROP KW_DEFAULT
 %token KW_TRUE KW_FALSE KW_AS KW_ADD KW_COLUMN
 
-%token<int_t> INT_LIT
-%token<float_t> FLOAT_LIT
+%token<int32_t> INT_LIT
+%token<float32_t> FLOAT_LIT
 %token<string_t> TK_ID STR_LIT
 %type<string_t> multipart_id_suffix alias_spec
 

--- a/parser.y
+++ b/parser.y
@@ -11,9 +11,9 @@ var statements statementList
 %}
 
 %union {
-    int32_t int32
+    int64_t int64
     string_t string
-    float32_t float32
+    float64_t float64
 
     expr_t expression
 
@@ -42,7 +42,7 @@ var statements statementList
 %token KW_NULL KW_IN KW_IS KW_AUTO_INCREMENT KW_JOIN KW_ON KW_GROUP KW_BY KW_DROP KW_DEFAULT
 %token KW_TRUE KW_FALSE KW_AS KW_ADD KW_COLUMN
 
-%token<int32_t> INT_LIT
+%token<int64_t> INT_LIT
 %token<float32_t> FLOAT_LIT
 %token<string_t> TK_ID STR_LIT
 %type<string_t> multipart_id_suffix alias_spec

--- a/statements.go
+++ b/statements.go
@@ -64,7 +64,13 @@ type insertStatement struct {
 }
 
 func (s *insertStatement) convert() interface{} {
-	return nil
+	values := map[string]interface{}{}
+
+	for i, columnName := range s.columnNames {
+		values[columnName] = s.values[i]
+	}
+
+	return common.NewInsertCommand(s.table, values)
 }
 
 func (s *insertStatement) execute() error {
@@ -114,7 +120,7 @@ type selectStatement struct {
 }
 
 func (s *selectStatement) convert() interface{} {
-	return nil
+	return common.NewSelectTableCommand(s.table)
 }
 
 func (s *selectStatement) execute() error {

--- a/types.go
+++ b/types.go
@@ -19,11 +19,11 @@ func (t *booleanType) size() int {
 }
 
 type charType struct {
-	length int
+	length int32
 }
 
 func (t *charType) size() int {
-	return t.length * charSize
+	return int(t.length) * charSize
 }
 
 type integerType struct {

--- a/types.go
+++ b/types.go
@@ -1,11 +1,11 @@
 package parser
 
 const (
-	booleanSize = 1
-	charSize    = 1
-	integerSize = 4
-	floatSize   = 4
-	datetimeSize = 4
+	booleanSize  = 1
+	charSize     = 1
+	integerSize  = 8
+	floatSize    = 8
+	datetimeSize = 8
 )
 
 type dataType interface {
@@ -20,7 +20,7 @@ func (t *booleanType) size() int {
 }
 
 type charType struct {
-	length int32
+	length int64
 }
 
 func (t *charType) size() int {


### PR DESCRIPTION
Standarizes types for literals to match types used in data module.

The following changes were made:
- Every int is now an int64
- Every float is still float64.
- Every identifier is now changed to uppercase.

Also adds missing conversion functions to InsertStatement, SelectStatement and datatype AST nodes.